### PR TITLE
Show 'missed' instead '0 damage' in the combat logs

### DIFF
--- a/src/game/handlers/explore.js
+++ b/src/game/handlers/explore.js
@@ -1,4 +1,5 @@
 import {
+  ifElse,
   propEq,
   always,
   toPairs,
@@ -73,10 +74,14 @@ export function render (_, player, result) {
         turn.rolls.aHit,
         turn.rolls.aSkill,
       ),
-      _('<b>%s</b> dealt <b>%s damage</b>\n',
-        last(split(' ', turn.attacker)),
-        turn.damage.toFixed(0),
-      ),
+      ifElse(
+        propEq('damage', 0),
+        t => _('<b>%s missed</b>\n', last(split(' ', t.attacker))),
+        t => _('<b>%s</b> dealt <b>%s damage</b>\n',
+          last(split(' ', t.attacker)),
+          t.damage.toFixed(0),
+        ),
+      )(turn),
       (turn.casts || []).map(cast =>
         _('%s <b>%s</b> cast for <b>%s %s</b>\n',
           cast.emoji,

--- a/src/game/handlers/explore.js
+++ b/src/game/handlers/explore.js
@@ -76,7 +76,7 @@ export function render (_, player, result) {
       ),
       ifElse(
         propEq('damage', 0),
-        t => _('<b>%s missed</b>\n', last(split(' ', t.attacker))),
+        t => _('<b>%s</b> <i>missed</i>\n', last(split(' ', t.attacker))),
         t => _('<b>%s</b> dealt <b>%s damage</b>\n',
           last(split(' ', t.attacker)),
           t.damage.toFixed(0),

--- a/src/game/i18n/en.po
+++ b/src/game/i18n/en.po
@@ -404,3 +404,21 @@ msgid "%s increased by 1!"
 msgstr[0] ""
 msgstr[1] ""
 
+#: src/game/handlers/inventory.js 59:17
+msgid "<b>%s</b> - Tier %s %s
+/%s_%s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/game/handlers/explore.js 48:13
+msgid "<b>%s missed</b>
+"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/game/handlers/explore.js 48:13
+msgid "<b>%s</b> <i>missed</i>
+"
+msgstr[0] ""
+msgstr[1] ""
+


### PR DESCRIPTION
Just a small change to show "missed" instead of "deals 0 damage"