### PR TITLE
Allow player change char while in combat

### DIFF
--- a/src/engine/providers/telegram.js
+++ b/src/engine/providers/telegram.js
@@ -14,6 +14,9 @@ function buildFilter (stream, regex) {
 }
 
 function sendMessage (bot, chat, message, options) {
+  if (process.env.TELEMMO_QUIET) {
+    return
+  }
   bot.sendMessage(chat, emoji.emojify(message), options)
   return Observable.of(false)
 }

--- a/src/game/core/char.js
+++ b/src/game/core/char.js
@@ -15,11 +15,6 @@ export function useChar (dao, playerId, char) {
       'teams.members.id': { $in: map(prop('id'), chars) },
       finishedAt: { $exists: false },
     }))
-    .then(ifElse(
-      pipe(length, equals(0)),
-      always(undefined),
-      () => Promise.reject(new Error('A combat is pending')),
-    ))
     .then(partial(dao.player.update, [
       { _id: playerId },
       { $set: { currentCharId: char.id } },

--- a/src/game/database/dao.js
+++ b/src/game/database/dao.js
@@ -50,7 +50,11 @@ function create (collection, document) {
     .then(pipe(always(sealed), renameId))
 }
 
-function destroy (collection, query) {
+function destroy (collection, query, options) {
+  if (options.hard) {
+    return collection.remove(query) 
+  }
+
   return collection.findOneAndUpdate(
     query, { $set: { deletedAt: new Date() } })
 }

--- a/src/game/tasks/resumeCombats.js
+++ b/src/game/tasks/resumeCombats.js
@@ -1,7 +1,6 @@
 import { ObjectId } from 'mongodb'
 import {
   assocPath,
-  identity,
   flatten,
   partial,
   filter,
@@ -15,7 +14,6 @@ import {
 
 
 import Promise from 'bluebird'
-import { Observable } from 'rx'
 
 import { start } from '../core/combat'
 import { exploreUntilDead } from '../core/explore'


### PR DESCRIPTION
This fixes the bad decision of blocking players from changing char while
in combat. Now the default behavior is to allow both creation and
change of characters. The only difference is that now all running
explorations are dropped when a new explore is requested, making the game
experience much better (I hope so).