### PR TITLE
Show equipment bonuses on /char_info

### DIFF
--- a/src/game/handlers/charInfo.js
+++ b/src/game/handlers/charInfo.js
@@ -27,11 +27,11 @@ import { capitalize } from './helpers'
 
 import models from '../models'
 
-function getEquippedIds (character) {
+function equippedIds (character) {
   return filter(pipe(isNil, not), values(character.equips))
 }
 
-function getEquipDetails (equipIds) {
+function equipDetails (equipIds) {
   return map(models.equips.find, equipIds)
 }
 
@@ -44,8 +44,9 @@ function formatStatBonus (val) {
 }
 
 function showBonus (equipBonuses, stat) {
-  if (not(has(stat, equipBonuses))) return ''
-  return `(${formatStatBonus(prop(stat, equipBonuses))})`
+  return has(stat, equipBonuses)
+    ? `(${formatStatBonus(prop(stat, equipBonuses))})`
+    : ''
 }
 
 export default function call (dao, provider, _, msg) {
@@ -67,7 +68,7 @@ export default function call (dao, provider, _, msg) {
     .then(char => ({
       char,
       equipBonuses: curry(showBonus)(
-        pipe(getEquippedIds, getEquipDetails, mergeEquipBonuses)(char),
+        pipe(equippedIds, equipDetails, mergeEquipBonuses)(char),
       ),
     }))
     .then(({ char, equipBonuses }) => ({


### PR DESCRIPTION
It's a improvement in /char_info to show the total stats bonuses from equipment.

For example:
![image](https://cloud.githubusercontent.com/assets/1426680/23112692/10fe592e-f711-11e6-9641-82dc476c4051.png)

Those are the stats bonuses from these equipments:
![image](https://cloud.githubusercontent.com/assets/1426680/23112688/05753190-f711-11e6-8415-6746d26dec9d.png)
