### PR TITLE
Implement commands to upgrade/refund large amount of stats

### DIFF
--- a/src/game/adapters/telegram/routes.js
+++ b/src/game/adapters/telegram/routes.js
@@ -58,7 +58,7 @@ export default [
     error: handlers.start
   },
   {
-    match: /\/up_(\w+)/,
+    match: /\/(refund|up|upgrade)_([a-z]+)(?:_(\d+))?/,
     handler: handlers.upStat,
     next: handlers.improveStats,
     condition: msg => msg.player.currentCharId,

--- a/src/game/handlers/charInfo.js
+++ b/src/game/handlers/charInfo.js
@@ -10,7 +10,7 @@ import { ObjectId } from 'mongodb'
 import { level, nextLevelBar } from '../core/level'
 import membersExp from '../core/membersExp'
 
-import { getCurrentStatPoints } from './statHelpers'
+import { unspentStatPoints } from './statHelpers'
 
 import {
   showBonus,
@@ -61,7 +61,7 @@ export default function call (dao, provider, _, msg) {
         _('<b>Reflex: </b> %s %s', char.ref, equipBonuses('ref')),
         _('<b>Accuracy: </b> %s %s', char.acc, equipBonuses('acc')),
         _('<b>Flow: </b> %s %s', char.flow, equipBonuses('flow')),
-        _('<b>StatPoints: </b> %s', getCurrentStatPoints(char)),
+        _('<b>StatPoints: </b> %s', unspentStatPoints(char)),
         '',
         _('Get stronger with /improve_stats.'),
         _('Equip yourself in /inventory.'),

--- a/src/game/handlers/statHelpers.js
+++ b/src/game/handlers/statHelpers.js
@@ -21,6 +21,16 @@ export function statUpgradeCost (currentStatScore, amountToIncrease = 1) {
   return upgradeCost + statUpgradeCost(currentStatScore + 1, amountToIncrease - 1)
 }
 
+export function affordableUpgrades (currentStatScore, availablePoints) {
+  const upgradeCost = statUpgradeCost(currentStatScore)
+  if (availablePoints < upgradeCost) { return 0 }
+
+  return 1 + affordableUpgrades(
+    currentStatScore + 1,
+    availablePoints - upgradeCost,
+  )
+}
+
 export function statDowngradeRefund (currentStatScore, amountToDecrease = 1) {
   return statUpgradeCost(currentStatScore - amountToDecrease, amountToDecrease)
 }

--- a/src/game/handlers/statHelpers.js
+++ b/src/game/handlers/statHelpers.js
@@ -1,3 +1,7 @@
+import {
+  values,
+} from 'ramda'
+
 export const statIds = {
   strength: 'str',
   constitution: 'con',
@@ -6,48 +10,38 @@ export const statIds = {
   flow: 'flow',
 }
 
-function cost (stat) {
-  return 5 * Math.floor(stat / 8) + 5
+export function statUpgradeCost (currentStatScore, amountToIncrease = 1) {
+  if (amountToIncrease <= 0) { return 0 }
+  const upgradeCost = (
+    currentStatScore < 5
+    ? 0
+    : 5 + (5 * Math.floor(currentStatScore / 8))
+  )
+
+  return upgradeCost + statUpgradeCost(currentStatScore + 1, amountToIncrease - 1)
 }
 
-export function getStatCost (char, statName) {
-  const statId = statIds[statName]
-  const statCost = cost(char[statId])
-  return statCost
+export function statDowngradeRefund (currentStatScore, amountToDecrease = 1) {
+  return statUpgradeCost(currentStatScore - amountToDecrease, amountToDecrease)
 }
 
-export function getStatSpent (char, statName) {
-  const statId = statIds[statName]
-
-  let totalCost = 0
-  let currentAmount = char[statId]
-  while (currentAmount > 5) {
-    totalCost += (cost(currentAmount -1))
-    currentAmount -= 1
-  }
-
-  return totalCost
+export function statPointsSpent (statScore) {
+  return statUpgradeCost(0, statScore)
 }
 
-export function getTotalStats (
-  char,
-  currentLevel = char.level,
-  points = 0
-) {
-  if (currentLevel === 0) { return points }
-  return getTotalStats(
-    char,
-    currentLevel -1,
-    points + currentLevel + 15
+export function totalStatPoints (charLevel) {
+  if (charLevel <= 0) { return 0 }
+  return charLevel + 15 + totalStatPoints(charLevel - 1)
+}
+
+export function totalStatPointsSpent (char) {
+  return values(statIds).reduce(
+    (acc, statId) => acc + statPointsSpent(char[statId]),
+    0,
   )
 }
-export function getSpent (char) {
-  const stats =
-    ['strength', 'constitution', 'reflex', 'accuracy', 'flow']
-      .reduce((acc, statName) => acc + getStatSpent(char, statName), 0)
-  return stats
-}
-export function getCurrentStatPoints (char) {
-  return getTotalStats(char) - getSpent(char)
+
+export function unspentStatPoints (char) {
+  return totalStatPoints(char.level) - totalStatPointsSpent(char)
 }
 

--- a/src/game/handlers/stats.test.js
+++ b/src/game/handlers/stats.test.js
@@ -1,8 +1,9 @@
 import {
-  getStatCost,
-  getStatSpent,
-  getTotalStats,
-  getSpent,
+  statUpgradeCost,
+  statDowngradeRefund,
+  totalStatPoints,
+  totalStatPointsSpent,
+  statPointsSpent,
 } from './statHelpers'
 
 const charMock = {
@@ -14,27 +15,38 @@ const charMock = {
   level: 100,
 }
 
-test('get cost', () => {
-  expect(getStatCost(charMock, 'strength')).toBe(5)
-  expect(getStatCost(charMock, 'constitution')).toBe(10)
-  expect(getStatCost(charMock, 'reflex')).toBe(15)
-  expect(getStatCost(charMock, 'accuracy')).toBe(30)
-  expect(getStatCost(charMock, 'flow')).toBe(60)
+test('get upgrade cost', () => {
+  expect(statUpgradeCost(charMock.str)).toBe(5)
+  expect(statUpgradeCost(charMock.con)).toBe(10)
+  expect(statUpgradeCost(charMock.ref)).toBe(15)
+  expect(statUpgradeCost(charMock.acc)).toBe(30)
+  expect(statUpgradeCost(charMock.flow)).toBe(60)
+  expect(statUpgradeCost(20, 6)).toBe(100)
+  expect(statUpgradeCost(15, 10)).toBe(150)
+})
+
+test('get downgrade refund', () => {
+  expect(statDowngradeRefund(charMock.str)).toBe(0)
+  expect(statDowngradeRefund(charMock.con)).toBe(10)
+  expect(statDowngradeRefund(charMock.ref)).toBe(10)
+  expect(statDowngradeRefund(charMock.acc)).toBe(30)
+  expect(statDowngradeRefund(charMock.flow)).toBe(60)
+  expect(statDowngradeRefund(26, 6)).toBe(100)
+  expect(statDowngradeRefund(25, 10)).toBe(150)
 })
 
 test('get total statPoints', () => {
-  expect(getTotalStats({ level: 6 })).toBe(111)
+  expect(totalStatPoints(6)).toBe(111)
 })
 
 test('get total spent for all stats', () => {
-  expect(getSpent({ str: 6, con: 5, ref: 5, acc: 5, flow: 5 })).toBe(5)
-  expect(getSpent({ str: 6, con: 5, ref: 6, acc: 5, flow: 5 })).toBe(10)
-  expect(getSpent({ str: 10, con: 5, ref: 6, acc: 5, flow: 5 })).toBe(40)
+  expect(totalStatPointsSpent({ str: 6, con: 5, ref: 5, acc: 5, flow: 5 })).toBe(5)
+  expect(totalStatPointsSpent({ str: 6, con: 5, ref: 6, acc: 5, flow: 5 })).toBe(10)
+  expect(totalStatPointsSpent({ str: 10, con: 5, ref: 6, acc: 5, flow: 5 })).toBe(40)
 })
 
-
 test('get total spent for one stat', () => {
-  expect(getStatSpent(charMock, 'strength')).toBe(0)
-  expect(getStatSpent(charMock, 'constitution')).toBe(25)
+  expect(statPointsSpent(charMock.str)).toBe(0)
+  expect(statPointsSpent(charMock.con)).toBe(25)
 })
 


### PR DESCRIPTION
Hey guys,

Players at high levels have been struggling on changing builds with the current commands that increase stats by 1. When they have 100+ stats it gets a bit annoying and probably stressful for the server, so I implemented some functions to improve this.

The old ones still work: `/up_flow` `/up_strength`
"upgrade" is accepted too: `/upgrade_flow` `/upgrade_strength`
I added a "refund" command: `/refund_flow` `/refund_strength`
And now amount can be added to any of them too: `/up_flow_10` `/refund_flow_25`

You may ask, "why isn't the parameter separated by space?", well it seems that with the current API of Telegram isn't possible to create a touchable/clickable link with a parameter separated by space, so using just underscore to separate the parameter let you link the parameter properly. IMO that could be useful at some point.

I'll appreciate any feedback for possible improvements.

GL guys.