### PR TITLE
Stance balancing

### DIFF
--- a/src/game/models/equips.js
+++ b/src/game/models/equips.js
@@ -1,3 +1,5 @@
+/* eslint no-unused-vars: ["error", { "argsIgnorePattern": "defender|rolls" }] */
+
 export default [
   // Weapons
   {
@@ -12,11 +14,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: rolls.aAim < 19,
       defender: {
-        hp: -2 - (attacker.level / 10),
+        hp: -2 - (attacker.level * 0.1),
       },
       log: {
         type: 'damage',
-        value: 2 + (attacker.level / 10),
+        value: 2 + (attacker.level * 0.1),
       },
     }),
   },
@@ -32,11 +34,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: rolls.aAim < 17,
       defender: {
-        hp: -5 - (attacker.level / 10),
+        hp: -5 - (attacker.level * 0.1),
       },
       log: {
         type: 'damage',
-        value: 5 + (attacker.level / 10),
+        value: 5 + (attacker.level * 0.1),
       },
     }),
   },
@@ -52,11 +54,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: rolls.aAim < 19,
       defender: {
-        hp: -3 - (attacker.level / 10),
+        hp: -3 - (attacker.level * 0.1),
       },
       log: {
         type: 'damage',
-        value: 3 + (attacker.level / 10),
+        value: 3 + (attacker.level * 0.1),
       },
     }),
   },
@@ -72,11 +74,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: rolls.aHit < 17,
       defender: {
-        hp: -10 - (attacker.level / 10),
+        hp: -10 - (attacker.level * 0.1),
       },
       log: {
         type: 'damage',
-        value: 10 + (attacker.level / 10),
+        value: 10 + (attacker.level * 0.1),
       },
     }),
   },
@@ -93,11 +95,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: rolls.aAim < 17,
       defender: {
-        hp: -4 - (attacker.level / 10),
+        hp: -4 - (attacker.level * 0.1),
       },
       log: {
         type: 'damage',
-        value: 4 + (attacker.level / 10),
+        value: 4 + (attacker.level * 0.1),
       },
     }),
   },
@@ -113,11 +115,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: (rolls.aHit < 15 || rolls.aAim < 15),
       defender: {
-        hp: -20 - (attacker.level / 5),
+        hp: -20 - (attacker.level * 0.2),
       },
       log: {
         type: 'damage',
-        value: 20 + (attacker.level / 5),
+        value: 20 + (attacker.level * 0.2),
       },
     }),
   },
@@ -133,11 +135,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: (rolls.aHit < 10),
       defender: {
-        hp: -13 - (attacker.level / 4),
+        hp: -13 - (attacker.level * 0.25),
       },
       log: {
         type: 'damage',
-        value: 13 + (attacker.level / 4),
+        value: 13 + (attacker.level * 0.25),
       },
     }),
   },
@@ -156,11 +158,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: (rolls.aAim < 15),
       defender: {
-        hp: -30 - (attacker.level / 4),
+        hp: -30 - (attacker.level * 0.25),
       },
       log: {
         type: 'damage',
-        value: 30 + (attacker.level / 4),
+        value: 30 + (attacker.level * 0.25),
       },
     }),
   },
@@ -179,11 +181,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: (rolls.aAim < 15),
       defender: {
-        hp: -35 - (attacker.level / 4),
+        hp: -35 - (attacker.level * 0.25),
       },
       log: {
         type: 'damage',
-        value: 35 + (attacker.level / 4),
+        value: 35 + (attacker.level * 0.25),
       },
     }),
   },
@@ -202,11 +204,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: (rolls.aAim < 15),
       defender: {
-        hp: -35 - (attacker.level / 4),
+        hp: -35 - (attacker.level * 0.25),
       },
       log: {
         type: 'damage',
-        value: 35 + (attacker.level / 4),
+        value: 35 + (attacker.level * 0.25),
       },
     }),
   },
@@ -225,11 +227,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: (rolls.aHit < 10),
       defender: {
-        hp: -20 - (attacker.level / 5),
+        hp: -20 - (attacker.level * 0.2),
       },
       log: {
         type: 'damage',
-        value: 20 + (attacker.level / 5),
+        value: 20 + (attacker.level * 0.2),
       },
     }),
   },
@@ -248,11 +250,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: (rolls.aHit < 14),
       defender: {
-        hp: -45 - (attacker.level / 4),
+        hp: -45 - (attacker.level * 0.25),
       },
       log: {
         type: 'damage',
-        value: 45 + (attacker.level / 4),
+        value: 45 + (attacker.level * 0.25),
       },
     }),
   },
@@ -272,11 +274,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: (rolls.aHit < 14),
       defender: {
-        hp: -50 - (attacker.level / 4),
+        hp: -50 - (attacker.level * 0.25),
       },
       log: {
         type: 'damage',
-        value: 50 + (attacker.level / 4),
+        value: 50 + (attacker.level * 0.25),
       },
     }),
   },
@@ -490,11 +492,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: rolls.aSkill < 19,
       attacker: {
-        hp: 5 + (attacker.level / 10),
+        hp: 5 + (attacker.level * 0.1),
       },
       log: {
         type: 'heal',
-        value: 5 + (attacker.level / 10),
+        value: 5 + (attacker.level * 0.1),
       },
     }),
   },
@@ -510,12 +512,12 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: rolls.aSkill < 18,
       attacker: {
-        hp: 10 + (attacker.level / 10),
+        hp: 10 + (attacker.level * 0.1),
         flow: attacker.flow * 0.1,
       },
       log: {
         type: 'heal (+FLOW)',
-        value: 10 + (attacker.level / 10),
+        value: 10 + (attacker.level * 0.1),
       },
     }),
   },
@@ -531,12 +533,12 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: rolls.aSkill < 15,
       attacker: {
-        hp: 10 + (attacker.level / 5),
+        hp: 10 + (attacker.level * 0.2),
         con: attacker.con * 0.2,
       },
       log: {
         type: 'heal (+CON)',
-        value: 10 + (attacker.level / 5),
+        value: 10 + (attacker.level * 0.2),
       },
     }),
   },
@@ -553,12 +555,12 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: rolls.aSkill < 15,
       attacker: {
-        hp: 15 + (attacker.level / 5),
+        hp: 15 + (attacker.level * 0.2),
         ref: attacker.ref * 0.2,
       },
       log: {
         type: 'heal (+REF)',
-        value: 15 + (attacker.level / 5),
+        value: 15 + (attacker.level * 0.2),
       },
     }),
   },
@@ -577,11 +579,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: rolls.aSkill < 15,
       attacker: {
-        hp: 15 + (attacker.level / 5),
+        hp: 15 + (attacker.level * 0.2),
       },
       log: {
         type: 'heal',
-        value: 15 + (attacker.level / 5),
+        value: 15 + (attacker.level * 0.2),
       },
     }),
   },
@@ -598,11 +600,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: rolls.aSkill < 14,
       attacker: {
-        hp: 20 + (attacker.level / 5),
+        hp: 20 + (attacker.level * 0.2),
       },
       log: {
         type: 'heal',
-        value: 20 + (attacker.level / 5),
+        value: 20 + (attacker.level * 0.2),
       },
     }),
   },
@@ -620,11 +622,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: (rolls.aAim < 16),
       defender: {
-        hp: -35 - (attacker.level / 4),
+        hp: -35 - (attacker.level * 0.25),
       },
       log: {
         type: 'damage',
-        value: 35 + (attacker.level / 4),
+        value: 35 + (attacker.level * 0.25),
       },
     }),
   },
@@ -642,11 +644,11 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: rolls.aSkill < 14,
       attacker: {
-        hp: 30 + (attacker.level / 4),
+        hp: 30 + (attacker.level * 0.25),
       },
       log: {
         type: 'heal',
-        value: 30 + (attacker.level / 4),
+        value: 30 + (attacker.level * 0.25),
       },
     }),
   },
@@ -663,12 +665,12 @@ export default [
     fire: (attacker, defender, rolls) => ({
       noCast: rolls.aSkill < 14,
       attacker: {
-        hp: 40 + (attacker.level / 4),
+        hp: 40 + (attacker.level * 0.25),
         ref: attacker.str * 0.2,
       },
       log: {
         type: 'heal (+STR)',
-        value: 40 + (attacker.level / 4),
+        value: 40 + (attacker.level * 0.25),
       },
     }),
   },

--- a/src/game/models/monsters.js
+++ b/src/game/models/monsters.js
@@ -434,6 +434,7 @@ t . Ice Ring
       tokens: ['ice_ring'],
     },
   },
+
 /* //////////////////////////////////////////////////////////////////////////////
 Volcanic Oasis
 
@@ -634,12 +635,15 @@ t . Dynamo
       tokens: ['dynamo'],
     },
   },
-  /* #<{(|//////////////////////////////////////////////////////////////////////////////
- Deeps Below
- w . Tentacle Whip, Plague Staff
- s . Golem, Unholy
- t . Pandora's Box Shard
- */
+
+/* #<{(|//////////////////////////////////////////////////////////////////////////////
+Deeps Below
+
+w . Tentacle Whip, Plague Staff
+s . Golem, Unholy
+t . Pandora's Box Shard
+
+*/
   {
     id: 'colossal_spider',
     name: 'Colossal Spider',

--- a/src/game/models/skills.js
+++ b/src/game/models/skills.js
@@ -7,11 +7,11 @@ export default [
     name: 'Pulse',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -15 + (attacker.level * 0.33),
+        hp: -15 + (attacker.level * 0.4),
       },
       log: {
         type: 'damage',
-        value: 15 + (attacker.level * 0.33),
+        value: 15 + (attacker.level * 0.4),
       },
     }),
   },
@@ -20,12 +20,12 @@ export default [
     name: 'Ice Shard',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -22 + (attacker.level * 0.25),
-        ref: -defender.ref * 0.2,
+        hp: -15 + (attacker.level * 0.25),
+        ref: -defender.flow * 0.15,
       },
       log: {
-        type: 'damage (-REF)',
-        value: 22 + (attacker.level * 0.25),
+        type: 'damage (-FLOW)',
+        value: 15 + (attacker.level * 0.25),
       },
     }),
   },
@@ -34,11 +34,11 @@ export default [
     name: 'Fireball',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -35 + (attacker.level * 0.33),
+        hp: -35 + (attacker.level * 0.45),
       },
       log: {
         type: 'damage',
-        value: 35 + (attacker.level * 0.33),
+        value: 35 + (attacker.level * 0.45),
       },
     }),
   },
@@ -47,11 +47,11 @@ export default [
     name: 'Maelstrom',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -50 + (attacker.level * 0.5),
+        hp: -45 + (attacker.level * 0.6),
       },
       log: {
         type: 'damage',
-        value: 50 + (attacker.level * 0.5),
+        value: 45 + (attacker.level * 0.6),
       },
     }),
   },
@@ -61,12 +61,12 @@ export default [
     name: 'Smog',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -11 + (attacker.level * 0.25),
-        acc: -defender.acc * 0.2,
+        hp: -7 + (attacker.level * 0.17),
+        acc: -defender.acc * 0.15,
       },
       log: {
         type: 'damage (-ACC)',
-        value: 11 + (attacker.level * 0.25),
+        value: 7 + (attacker.level * 0.17),
       },
     }),
   },
@@ -75,12 +75,12 @@ export default [
     name: 'Slime',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -22 + (attacker.level * 0.25),
-        ref: -defender.ref * 0.3,
+        hp: -15 + (attacker.level * 0.25),
+        ref: -defender.ref * 0.15,
       },
       log: {
         type: 'damage (-REF)',
-        value: 22 + (attacker.level * 0.25),
+        value: 15 + (attacker.level * 0.25),
       },
     }),
   },
@@ -89,13 +89,13 @@ export default [
     name: 'Confusion',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -12 + (attacker.level * 0.25),
-        str: -defender.str * 0.3,
-        con: -defender.con * 0.3,
+        hp: -20 + (attacker.level * 0.25),
+        str: -defender.str * 0.15,
+        con: -defender.con * 0.15,
       },
       log: {
         type: 'damage (-STR -CON)',
-        value: 12 + (attacker.level * 0.25),
+        value: 20 + (attacker.level * 0.25),
       },
     }),
   },
@@ -104,26 +104,26 @@ export default [
     name: 'Mirage',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -1 + (attacker.level * 0.2),
-        acc: -defender.acc * 0.35,
-        ref: -defender.ref * 0.35,
-        str: -defender.str * 0.35,
-        con: -defender.con * 0.35,
-        flow: -defender.flow * 0.35,
+        hp: -15 + (attacker.level * 0.15),
+        acc: -defender.acc * 0.11,
+        ref: -defender.ref * 0.11,
+        str: -defender.str * 0.11,
+        con: -defender.con * 0.11,
+        flow: -defender.flow * 0.11,
       },
       log: {
         type: 'damage (-ALL STATS)',
-        value: 1 + (attacker.level * 0.2),
+        value: 15 + (attacker.level * 0.15),
       },
     }),
   },
   // Endure - Fighter
   {
-    id: 'meditate',
-    name: 'Meditate',
+    id: 'taunt',
+    name: 'Taunt',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -1 + (attacker.level * 0.2),
+        hp: -7 + (attacker.level * 0.17),
       },
       attacker: {
         str: defender.str * 0.1,
@@ -131,7 +131,7 @@ export default [
       },
       log: {
         type: 'damage (+STR +ACC)',
-        value: 1 + (attacker.level * 0.2),
+        value: 7 + (attacker.level * 0.17),
       },
     }),
   },
@@ -140,11 +140,11 @@ export default [
     name: 'Bandage',
     fire: (attacker, defender, rolls) => ({
       attacker: {
-        hp: 10 + (attacker.level * 0.25),
+        hp: 15 + (attacker.level * 0.25),
       },
       log: {
         type: 'heal',
-        value: 10 + (attacker.level * 0.25),
+        value: 15 + (attacker.level * 0.25),
       },
     }),
   },
@@ -153,12 +153,12 @@ export default [
     name: 'Shield Bash',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -30 + (attacker.level * 0.25),
-        flow: -defender.flow * 0.1,
+        hp: -25 + (attacker.level * 0.35),
+        flow: -defender.flow * 0.15,
       },
       log: {
         type: 'damage (-FLOW)',
-        value: 30 + (attacker.level * 0.25),
+        value: 25 + (attacker.level * 0.35),
       },
     }),
   },
@@ -169,11 +169,11 @@ export default [
       attacker: {
         str: attacker.str * 0.3,
         con: attacker.con * 0.3,
-        hp: 10 + (attacker.level * 0.25),
+        hp: 16 + (attacker.level * 0.2),
       },
       log: {
         type: 'heal (+STR +CON)',
-        value: 10 + (attacker.level * 0.25),
+        value: 16 + (attacker.level * 0.2),
       },
     }),
   },
@@ -183,7 +183,7 @@ export default [
     name: 'Rage',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -10 + (attacker.level * 0.25),
+        hp: -7 + (attacker.level * 0.17),
       },
       attacker: {
         str: attacker.str * 0.1,
@@ -191,7 +191,7 @@ export default [
       },
       log: {
         type: 'damage (+STR +CON)',
-        value: 10 + (attacker.level * 0.25),
+        value: 7 + (attacker.level * 0.17),
       },
     }),
   },
@@ -200,11 +200,11 @@ export default [
     name: 'Fast Strike',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -20 + (attacker.level * 0.25),
+        hp: -20 + (attacker.level * 0.35),
       },
       log: {
         type: 'damage',
-        value: 20 + (attacker.level * 0.25),
+        value: 20 + (attacker.level * 0.35),
       },
     }),
   },
@@ -217,7 +217,7 @@ export default [
       },
       attacker: {
         str: attacker.str * 0.25,
-        ref: attacker.ref * 0.25,
+        ref: attacker.ref * 0.15,
       },
       log: {
         type: 'damage (+STR +REF)',
@@ -230,11 +230,11 @@ export default [
     name: 'Massacre',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -35 + (attacker.level * 0.5),
+        hp: -40 + (attacker.level * 0.55),
       },
       log: {
         type: 'damage',
-        value: -35 + (attacker.level * 0.5),
+        value: -40 + (attacker.level * 0.55),
       },
     }),
   },
@@ -244,12 +244,12 @@ export default [
     name: 'Poison Dart',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -10 + (attacker.level * 0.25),
-        ref: -defender.ref * 0.2,
+        hp: -7 + (attacker.level * 0.17),
+        ref: -defender.ref * 0.15,
       },
       log: {
         type: 'damage (-REF)',
-        value: 10 + (attacker.level * 0.25),
+        value: 7 + (attacker.level * 0.17),
       },
     }),
   },
@@ -258,12 +258,12 @@ export default [
     name: 'Sand Attack',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -20 + (attacker.level * 0.25),
-        acc: -defender.acc * 0.2,
+        hp: -15 + (attacker.level * 0.25),
+        acc: -defender.acc * 0.15,
       },
       log: {
         type: 'damage (-ACC)',
-        value: 20 + (attacker.level * 0.25),
+        value: 15 + (attacker.level * 0.25),
       },
     }),
   },
@@ -272,11 +272,11 @@ export default [
     name: 'Deep Cut',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -30 + (attacker.level * 0.25),
+        hp: -30 + (attacker.level * 0.45),
       },
       log: {
         type: 'damage',
-        value: 30 + (attacker.level * 0.25),
+        value: 30 + (attacker.level * 0.45),
       },
     }),
   },
@@ -285,13 +285,13 @@ export default [
     name: 'Toxic Ballista',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -35 + (attacker.level * 0.25),
-        acc: -defender.acc * 0.2,
-        ref: -defender.ref * 0.2,
+        hp: -17 + (attacker.level * 0.17),
+        acc: -defender.acc * 0.225,
+        ref: -defender.ref * 0.225,
       },
       log: {
         type: 'damage (-ACC -REF)',
-        value: 35 + (attacker.level * 0.25),
+        value: 17 + (attacker.level * 0.17),
       },
     }),
   },
@@ -301,7 +301,7 @@ export default [
     name: 'Smoke Screen',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -10 + (attacker.level * 0.2),
+        hp: -7 + (attacker.level * 0.17),
       },
       attacker: {
         acc: attacker.acc * 0.1,
@@ -309,7 +309,7 @@ export default [
       },
       log: {
         type: 'damage (+ACC +REF)',
-        value: 10 + (attacker.level * 0.2),
+        value: 7 + (attacker.level * 0.17),
       },
     }),
   },
@@ -318,15 +318,15 @@ export default [
     name: 'Conceal',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -20 + (attacker.level * 0.2),
+        hp: -10 + (attacker.level * 0.15),
       },
       attacker: {
-        acc: attacker.acc * 0.3,
-        ref: attacker.ref * 0.3,
+        acc: attacker.acc * 0.2,
+        ref: attacker.ref * 0.2,
       },
       log: {
         type: 'damage (+ACC +REF)',
-        value: 20 + (attacker.level * 0.2),
+        value: 10 + (attacker.level * 0.15),
       },
     }),
   },
@@ -335,11 +335,11 @@ export default [
     name: 'Shadow Strike',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -50 + (attacker.level * 0.25),
+        hp: -30 + (attacker.level * 0.45),
       },
       log: {
         type: 'damage',
-        value: 50 + (attacker.level * 0.25),
+        value: 30 + (attacker.level * 0.45),
       },
     }),
   },
@@ -348,11 +348,11 @@ export default [
     name: 'Deathstab',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -50 + (attacker.level * 0.25),
+        hp: -40 + (attacker.level * 0.55),
       },
       log: {
         type: 'damage',
-        value: 50 + (attacker.level * 0.25),
+        value: 40 + (attacker.level * 0.55),
       },
     }),
   },
@@ -375,11 +375,11 @@ export default [
     name: 'Mantis Slash',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -20 + (attacker.level * 0.25),
+        hp: -20 + (attacker.level * 0.35),
       },
       log: {
         type: 'damage',
-        value: 20 + (attacker.level * 0.25),
+        value: 20 + (attacker.level * 0.35),
       },
     }),
   },
@@ -388,7 +388,7 @@ export default [
     name: 'Ying Strike',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -30 + (attacker.level * 0.25),
+        hp: -20 + (attacker.level * 0.25),
       },
       attacker: {
         str: attacker.str * 0.2,
@@ -396,7 +396,7 @@ export default [
       },
       log: {
         type: 'damage (+STR +ACC)',
-        value: 30 + (attacker.level * 0.25),
+        value: 20 + (attacker.level * 0.25),
       },
     }),
   },
@@ -405,11 +405,11 @@ export default [
     name: 'Emerald Punch',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -40 + (attacker.level * 0.33),
+        hp: -40 + (attacker.level * 0.55),
       },
       log: {
         type: 'damage',
-        value: 40 + (attacker.level * 0.33),
+        value: 40 + (attacker.level * 0.55),
       },
     }),
   },
@@ -432,7 +432,7 @@ export default [
     name: 'Bless',
     fire: (attacker, defender, rolls) => ({
       attacker: {
-        hp: attacker.level * 0.2,
+        hp: 10 + (attacker.level * 0.2),
         con: attacker.con * 0.2,
       },
       log: {
@@ -446,7 +446,7 @@ export default [
     name: 'Power Aura',
     fire: (attacker, defender, rolls) => ({
       attacker: {
-        hp: attacker.level * 0.2,
+        hp: 10 + (attacker.level * 0.2),
         str: attacker.str * 0.4,
       },
       log: {
@@ -460,11 +460,11 @@ export default [
     name: 'Divine Beam',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -50 + (attacker.level * 0.2),
+        hp: -40 + (attacker.level * 0.55),
       },
       log: {
         type: 'damage',
-        value: 50 + (attacker.level * 0.2),
+        value: 40 + (attacker.level * 0.55),
       },
     }),
   },
@@ -474,14 +474,14 @@ export default [
     name: 'Scope',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -10 + (attacker.level * 0.25),
+        hp: -7 + (attacker.level * 0.17),
       },
       attacker: {
         acc: attacker.acc * 0.2,
       },
       log: {
         type: 'damage (+ACC)',
-        value: 10 + (attacker.level * 0.25),
+        value: 7 + (attacker.level * 0.17),
       },
     }),
   },
@@ -490,14 +490,14 @@ export default [
     name: 'Herbal Scent',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -20 + (attacker.level * 0.25),
+        hp: -15 + (attacker.level * 0.25),
       },
       attacker: {
         con: attacker.con * 0.2,
       },
       log: {
         type: 'damage (+CON)',
-        value: 20 + (attacker.level * 0.25),
+        value: 15 + (attacker.level * 0.25),
       },
     }),
   },
@@ -506,11 +506,11 @@ export default [
     name: 'Power Arrow',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -40 + (attacker.level * 0.25),
+        hp: -30 + (attacker.level * 0.45),
       },
       log: {
         type: 'damage',
-        value: 40 + (attacker.level * 0.25),
+        value: 30 + (attacker.level * 0.55),
       },
     }),
   },
@@ -519,11 +519,11 @@ export default [
     name: 'Headshot',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -40 + (attacker.level * 0.5),
+        hp: -40 + (attacker.level * 0.55),
       },
       log: {
         type: 'damage',
-        value: 40 + (attacker.level * 0.5),
+        value: 40 + (attacker.level * 0.55),
       },
     }),
   },
@@ -533,12 +533,12 @@ export default [
     name: 'Tripwire',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -10 + (attacker.level * 0.142),
-        ref: -defender.ref * 0.2,
+        hp: -7 + (attacker.level * 0.17),
+        ref: -defender.ref * 0.15,
       },
       log: {
         type: 'damage (-REF)',
-        value: 10 + (attacker.level * 0.142),
+        value: 7 + (attacker.level * 0.17),
       },
     }),
   },
@@ -547,14 +547,14 @@ export default [
     name: 'Patience',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -20 + (attacker.level * 0.25),
+        hp: -15 + (attacker.level * 0.25),
       },
       attacker: {
         flow: attacker.flow * 0.2,
       },
       log: {
         type: 'damage (+FLOW)',
-        value: 20 + (attacker.level * 0.25),
+        value: 15 + (attacker.level * 0.25),
       },
     }),
   },
@@ -563,13 +563,13 @@ export default [
     name: 'Bear Trap',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -10 + (attacker.level * 0.25),
-        ref: -defender.ref * 0.3,
-        acc: -defender.acc * 0.3,
+        hp: -20 + (attacker.level * 0.25),
+        ref: -defender.ref * 0.15,
+        acc: -defender.acc * 0.15,
       },
       log: {
         type: 'damage (-REF -ACC)',
-        value: 10 + (attacker.level * 0.25),
+        value: 20 + (attacker.level * 0.25),
       },
     }),
   },
@@ -578,11 +578,11 @@ export default [
     name: 'Explosive Charge',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -40 + (attacker.level * 0.5),
+        hp: -40 + (attacker.level * 0.55),
       },
       log: {
         type: 'damage',
-        value: -40 + (attacker.level * 0.5),
+        value: -40 + (attacker.level * 0.55),
       },
     }),
   },
@@ -592,12 +592,12 @@ export default [
     name: 'Tune Weapon',
     fire: (attacker, defender, rolls) => ({
       attacker: {
-        hp: 2 + (attacker.level * 0.2),
+        hp: 7 + (attacker.level * 0.15),
         str: attacker.str * 0.2,
       },
       log: {
         type: 'heal (+STR)',
-        value: 2 + (attacker.level * 0.2),
+        value: 7 + (attacker.level * 0.15),
       },
     }),
   },
@@ -606,11 +606,11 @@ export default [
     name: 'Potion',
     fire: (attacker, defender, rolls) => ({
       attacker: {
-        hp: 20 + (attacker.level * 0.25),
+        hp: 15 + (attacker.level * 0.25),
       },
       log: {
         type: 'heal',
-        value: 20 + (attacker.level * 0.25),
+        value: 15 + (attacker.level * 0.25),
       },
     }),
   },
@@ -619,11 +619,11 @@ export default [
     name: 'Runover',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -35 + (attacker.level * 0.2),
+        hp: -35 + (attacker.level * 0.45),
       },
       log: {
         type: 'damage',
-        value: 35 + (attacker.level * 0.2),
+        value: 35 + (attacker.level * 0.45),
       },
     }),
   },
@@ -632,12 +632,12 @@ export default [
     name: 'Chemical Bomb',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -10 + (attacker.level * 0.25),
+        hp: -25 + (attacker.level * 0.3),
         con: -defender.con * 0.3,
       },
       log: {
         type: 'damage (-CON)',
-        value: 10 + (attacker.level * 0.25),
+        value: 25 + (attacker.level * 0.3),
       },
     }),
   },
@@ -647,12 +647,12 @@ export default [
     name: 'Smart Hit',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -15 + (attacker.level * 0.25),
-        ref: -defender.ref * 0.2,
+        hp: -7 + (attacker.level * 0.17),
+        ref: -defender.ref * 0.15,
       },
       log: {
         type: 'damage (-REF)',
-        value: 15 + (attacker.level * 0.25),
+        value: 7 + (attacker.level * 0.17),
       },
     }),
   },
@@ -661,12 +661,12 @@ export default [
     name: 'Calculated Blow',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -20 + (attacker.level * 0.25),
-        con: -defender.con * 0.1,
+        hp: -15 + (attacker.level * 0.25),
+        con: -defender.con * 0.15,
       },
       log: {
         type: 'damage (-CON)',
-        value: 20 + (attacker.level * 0.25),
+        value: 15 + (attacker.level * 0.25),
       },
     }),
   },
@@ -675,15 +675,13 @@ export default [
     name: 'Sabotage',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -25 + (attacker.level * 0.25),
-        str: -defender.str * 0.1,
-        ref: -defender.ref * 0.1,
-        acc: -defender.acc * 0.1,
-        con: -defender.con * 0.1,
+        hp: -20 + (attacker.level * 0.25),
+        ref: -defender.ref * 0.15,
+        acc: -defender.acc * 0.15,
       },
       log: {
-        type: 'damage (-STR -CON -REF -ACC)',
-        value: 25 + (attacker.level * 0.25),
+        type: 'damage (-REF -ACC)',
+        value: 20 + (attacker.level * 0.25),
       },
     }),
   },
@@ -692,16 +690,13 @@ export default [
     name: 'Hammer Down',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: -20 + (attacker.level * 0.2),
-        acc: -defender.acc * 0.3,
-        ref: -defender.ref * 0.3,
-        str: -defender.str * 0.3,
-        con: -defender.con * 0.3,
-        flow: -defender.flow * 0.3,
+        hp: -25 + (attacker.level * 0.3),
+        str: -defender.str * 0.15,
+        con: -defender.con * 0.15,
       },
       log: {
-        type: 'damage (-ALL STATS)',
-        value: 20 + (attacker.level * 0.2),
+        type: 'damage (-CON -STR)',
+        value: 25 + (attacker.level * 0.3),
       },
     }),
   },

--- a/src/game/models/skills.js
+++ b/src/game/models/skills.js
@@ -1,3 +1,5 @@
+/* eslint no-unused-vars: ["error", { "argsIgnorePattern": "defender|rolls" }] */
+
 export default [
   // Arcane -  Mage
   {
@@ -5,11 +7,11 @@ export default [
     name: 'Pulse',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (15 + attacker.level/3),
+        hp: -15 + (attacker.level * 0.33),
       },
       log: {
         type: 'damage',
-        value: (15 + attacker.level/3),
+        value: 15 + (attacker.level * 0.33),
       },
     }),
   },
@@ -18,12 +20,12 @@ export default [
     name: 'Ice Shard',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (22 + attacker.level/4),
-        ref: - (defender.ref * 0.2)
+        hp: -22 + (attacker.level * 0.25),
+        ref: -defender.ref * 0.2,
       },
       log: {
         type: 'damage (-REF)',
-        value: (22 + attacker.level/4),
+        value: 22 + (attacker.level * 0.25),
       },
     }),
   },
@@ -32,11 +34,11 @@ export default [
     name: 'Fireball',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (35 + attacker.level/3),
+        hp: -35 + (attacker.level * 0.33),
       },
       log: {
         type: 'damage',
-        value: (35 + attacker.level/3),
+        value: 35 + (attacker.level * 0.33),
       },
     }),
   },
@@ -45,11 +47,11 @@ export default [
     name: 'Maelstrom',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (50 + attacker.level/2),
+        hp: -50 + (attacker.level * 0.5),
       },
       log: {
         type: 'damage',
-        value: (50 + attacker.level/2),
+        value: 50 + (attacker.level * 0.5),
       },
     }),
   },
@@ -59,12 +61,12 @@ export default [
     name: 'Smog',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (11 + attacker.level/4),
-        acc: - (defender.acc * 0.2)
+        hp: -11 + (attacker.level * 0.25),
+        acc: -defender.acc * 0.2,
       },
       log: {
         type: 'damage (-ACC)',
-        value: (11 + attacker.level/4),
+        value: 11 + (attacker.level * 0.25),
       },
     }),
   },
@@ -73,12 +75,12 @@ export default [
     name: 'Slime',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (22 + attacker.level/4),
-        ref: - (defender.ref * 0.3)
+        hp: -22 + (attacker.level * 0.25),
+        ref: -defender.ref * 0.3,
       },
       log: {
         type: 'damage (-REF)',
-        value: (22 + attacker.level/4),
+        value: 22 + (attacker.level * 0.25),
       },
     }),
   },
@@ -87,13 +89,13 @@ export default [
     name: 'Confusion',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (12 + attacker.level/4),
-        str: - (defender.str * 0.3),
-        con: - (defender.con * 0.3),
+        hp: -12 + (attacker.level * 0.25),
+        str: -defender.str * 0.3,
+        con: -defender.con * 0.3,
       },
       log: {
         type: 'damage (-STR -CON)',
-        value: (12 + attacker.level/4),
+        value: 12 + (attacker.level * 0.25),
       },
     }),
   },
@@ -102,16 +104,16 @@ export default [
     name: 'Mirage',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (1 + attacker.level/5),
-        acc: - (defender.acc * 0.35),
-        ref: - (defender.ref * 0.35),
-        str: - (defender.str * 0.35),
-        con: - (defender.con * 0.35),
-        flow: - (defender.flow * 0.35),
+        hp: -1 + (attacker.level * 0.2),
+        acc: -defender.acc * 0.35,
+        ref: -defender.ref * 0.35,
+        str: -defender.str * 0.35,
+        con: -defender.con * 0.35,
+        flow: -defender.flow * 0.35,
       },
       log: {
         type: 'damage (-ALL STATS)',
-        value: (1 + attacker.level/5),
+        value: 1 + (attacker.level * 0.2),
       },
     }),
   },
@@ -121,7 +123,7 @@ export default [
     name: 'Meditate',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (1 + attacker.level/5),
+        hp: -1 + (attacker.level * 0.2),
       },
       attacker: {
         str: defender.str * 0.1,
@@ -129,7 +131,7 @@ export default [
       },
       log: {
         type: 'damage (+STR +ACC)',
-        value: (1 + attacker.level/5),
+        value: 1 + (attacker.level * 0.2),
       },
     }),
   },
@@ -138,11 +140,11 @@ export default [
     name: 'Bandage',
     fire: (attacker, defender, rolls) => ({
       attacker: {
-        hp: (10 + attacker.level/4),
+        hp: 10 + (attacker.level * 0.25),
       },
       log: {
         type: 'heal',
-        value: (10 + attacker.level/4),
+        value: 10 + (attacker.level * 0.25),
       },
     }),
   },
@@ -151,12 +153,12 @@ export default [
     name: 'Shield Bash',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (30 + attacker.level/4),
-        flow: - (defender.flow * 0.1),
+        hp: -30 + (attacker.level * 0.25),
+        flow: -defender.flow * 0.1,
       },
       log: {
         type: 'damage (-FLOW)',
-        value: (30 + attacker.level/4),
+        value: 30 + (attacker.level * 0.25),
       },
     }),
   },
@@ -167,11 +169,11 @@ export default [
       attacker: {
         str: attacker.str * 0.3,
         con: attacker.con * 0.3,
-        hp: 10 + attacker.level/4,
+        hp: 10 + (attacker.level * 0.25),
       },
       log: {
         type: 'heal (+STR +CON)',
-        value: (10 + attacker.level/4),
+        value: 10 + (attacker.level * 0.25),
       },
     }),
   },
@@ -181,7 +183,7 @@ export default [
     name: 'Rage',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (10 + attacker.level/4),
+        hp: -10 + (attacker.level * 0.25),
       },
       attacker: {
         str: attacker.str * 0.1,
@@ -189,7 +191,7 @@ export default [
       },
       log: {
         type: 'damage (+STR +CON)',
-        value: (10 + attacker.level/4),
+        value: 10 + (attacker.level * 0.25),
       },
     }),
   },
@@ -198,11 +200,11 @@ export default [
     name: 'Fast Strike',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (20 + attacker.level/4),
+        hp: -20 + (attacker.level * 0.25),
       },
       log: {
         type: 'damage',
-        value: (20 + attacker.level/4),
+        value: 20 + (attacker.level * 0.25),
       },
     }),
   },
@@ -211,7 +213,7 @@ export default [
     name: 'Blood Mask',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (20 + attacker.level/4),
+        hp: -20 + (attacker.level * 0.25),
       },
       attacker: {
         str: attacker.str * 0.25,
@@ -219,7 +221,7 @@ export default [
       },
       log: {
         type: 'damage (+STR +REF)',
-        value: (20 + attacker.level/4),
+        value: 20 + (attacker.level * 0.25),
       },
     }),
   },
@@ -228,11 +230,11 @@ export default [
     name: 'Massacre',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (35 + attacker.level/2),
+        hp: -35 + (attacker.level * 0.5),
       },
       log: {
         type: 'damage',
-        value: - (35 + attacker.level/2),
+        value: -35 + (attacker.level * 0.5),
       },
     }),
   },
@@ -242,12 +244,12 @@ export default [
     name: 'Poison Dart',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (10 + attacker.level/4),
-        ref: - (defender.ref * 0.2)
+        hp: -10 + (attacker.level * 0.25),
+        ref: -defender.ref * 0.2,
       },
       log: {
         type: 'damage (-REF)',
-        value: (10 + attacker.level/4),
+        value: 10 + (attacker.level * 0.25),
       },
     }),
   },
@@ -256,12 +258,12 @@ export default [
     name: 'Sand Attack',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (20 + attacker.level/4),
-        acc: - (defender.acc * 0.2)
+        hp: -20 + (attacker.level * 0.25),
+        acc: -defender.acc * 0.2,
       },
       log: {
         type: 'damage (-ACC)',
-        value: (20 + attacker.level/4),
+        value: 20 + (attacker.level * 0.25),
       },
     }),
   },
@@ -270,11 +272,11 @@ export default [
     name: 'Deep Cut',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (30 + attacker.level/4),
+        hp: -30 + (attacker.level * 0.25),
       },
       log: {
         type: 'damage',
-        value: (30 + attacker.level/4),
+        value: 30 + (attacker.level * 0.25),
       },
     }),
   },
@@ -283,13 +285,13 @@ export default [
     name: 'Toxic Ballista',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (35 + attacker.level/4),
-        acc: - (defender.acc * 0.2),
-        ref: - (defender.ref * 0.2),
+        hp: -35 + (attacker.level * 0.25),
+        acc: -defender.acc * 0.2,
+        ref: -defender.ref * 0.2,
       },
       log: {
         type: 'damage (-ACC -REF)',
-        value: (35 + attacker.level/4),
+        value: 35 + (attacker.level * 0.25),
       },
     }),
   },
@@ -299,7 +301,7 @@ export default [
     name: 'Smoke Screen',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (10 + attacker.level/5),
+        hp: -10 + (attacker.level * 0.2),
       },
       attacker: {
         acc: attacker.acc * 0.1,
@@ -307,7 +309,7 @@ export default [
       },
       log: {
         type: 'damage (+ACC +REF)',
-        value: (10 + attacker.level/5),
+        value: 10 + (attacker.level * 0.2),
       },
     }),
   },
@@ -316,7 +318,7 @@ export default [
     name: 'Conceal',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (20 + attacker.level/5),
+        hp: -20 + (attacker.level * 0.2),
       },
       attacker: {
         acc: attacker.acc * 0.3,
@@ -324,7 +326,7 @@ export default [
       },
       log: {
         type: 'damage (+ACC +REF)',
-        value: (20 + attacker.level/5),
+        value: 20 + (attacker.level * 0.2),
       },
     }),
   },
@@ -333,11 +335,11 @@ export default [
     name: 'Shadow Strike',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (50 + attacker.level/4),
+        hp: -50 + (attacker.level * 0.25),
       },
       log: {
         type: 'damage',
-        value: (50 + attacker.level/4),
+        value: 50 + (attacker.level * 0.25),
       },
     }),
   },
@@ -346,11 +348,11 @@ export default [
     name: 'Deathstab',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (50 + attacker.level/4),
+        hp: -50 + (attacker.level * 0.25),
       },
       log: {
         type: 'damage',
-        value: (50 + attacker.level/4),
+        value: 50 + (attacker.level * 0.25),
       },
     }),
   },
@@ -360,11 +362,11 @@ export default [
     name: 'Knuckles',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (10 + attacker.level/4),
+        hp: -10 + (attacker.level * 0.25),
       },
       log: {
         type: 'damage',
-        value: (10 + attacker.level/4),
+        value: 10 + (attacker.level * 0.25),
       },
     }),
   },
@@ -373,11 +375,11 @@ export default [
     name: 'Mantis Slash',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (20 + attacker.level/4),
+        hp: -20 + (attacker.level * 0.25),
       },
       log: {
         type: 'damage',
-        value: (20 + attacker.level/4),
+        value: 20 + (attacker.level * 0.25),
       },
     }),
   },
@@ -386,7 +388,7 @@ export default [
     name: 'Ying Strike',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (30 + attacker.level/4),
+        hp: -30 + (attacker.level * 0.25),
       },
       attacker: {
         str: attacker.str * 0.2,
@@ -394,7 +396,7 @@ export default [
       },
       log: {
         type: 'damage (+STR +ACC)',
-        value: (30 + attacker.level/4),
+        value: 30 + (attacker.level * 0.25),
       },
     }),
   },
@@ -403,11 +405,11 @@ export default [
     name: 'Emerald Punch',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (40 + attacker.level/3),
+        hp: -40 + (attacker.level * 0.33),
       },
       log: {
         type: 'damage',
-        value: (40 + attacker.level/3),
+        value: 40 + (attacker.level * 0.33),
       },
     }),
   },
@@ -417,11 +419,11 @@ export default [
     name: 'Heal',
     fire: (attacker, defender, rolls) => ({
       attacker: {
-        hp: (10 + attacker.level/5),
+        hp: 10 + (attacker.level * 0.2),
       },
       log: {
         type: 'heal',
-        value: (10 + attacker.level/5),
+        value: 10 + (attacker.level * 0.2),
       },
     }),
   },
@@ -430,12 +432,12 @@ export default [
     name: 'Bless',
     fire: (attacker, defender, rolls) => ({
       attacker: {
-        hp: (attacker.level/5),
-        con: attacker.con * 0.2
+        hp: attacker.level * 0.2,
+        con: attacker.con * 0.2,
       },
       log: {
         type: 'heal (+CON)',
-        value: (attacker.level/5),
+        value: attacker.level * 0.2,
       },
     }),
   },
@@ -444,12 +446,12 @@ export default [
     name: 'Power Aura',
     fire: (attacker, defender, rolls) => ({
       attacker: {
-        hp: (attacker.level/5),
-        str: attacker.str * 0.4
+        hp: attacker.level * 0.2,
+        str: attacker.str * 0.4,
       },
       log: {
         type: 'heal (+STR)',
-        value: (attacker.level/5),
+        value: attacker.level * 0.2,
       },
     }),
   },
@@ -458,11 +460,11 @@ export default [
     name: 'Divine Beam',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - ( 50 + (attacker.level/5)),
+        hp: -50 + (attacker.level * 0.2),
       },
       log: {
         type: 'damage',
-        value: (50 + attacker.level/5),
+        value: 50 + (attacker.level * 0.2),
       },
     }),
   },
@@ -472,14 +474,14 @@ export default [
     name: 'Scope',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (10 + attacker.level/4),
+        hp: -10 + (attacker.level * 0.25),
       },
       attacker: {
         acc: attacker.acc * 0.2,
       },
       log: {
         type: 'damage (+ACC)',
-        value: (10 + attacker.level/4),
+        value: 10 + (attacker.level * 0.25),
       },
     }),
   },
@@ -488,14 +490,14 @@ export default [
     name: 'Herbal Scent',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (20 + attacker.level/4),
+        hp: -20 + (attacker.level * 0.25),
       },
       attacker: {
         con: attacker.con * 0.2,
       },
       log: {
         type: 'damage (+CON)',
-        value: (20 + attacker.level/4),
+        value: 20 + (attacker.level * 0.25),
       },
     }),
   },
@@ -504,11 +506,11 @@ export default [
     name: 'Power Arrow',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (40 + attacker.level/4),
+        hp: -40 + (attacker.level * 0.25),
       },
       log: {
         type: 'damage',
-        value: (40 + attacker.level/4),
+        value: 40 + (attacker.level * 0.25),
       },
     }),
   },
@@ -517,11 +519,11 @@ export default [
     name: 'Headshot',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (40 + attacker.level/2),
+        hp: -40 + (attacker.level * 0.5),
       },
       log: {
         type: 'damage',
-        value: (40 + attacker.level/2),
+        value: 40 + (attacker.level * 0.5),
       },
     }),
   },
@@ -531,12 +533,12 @@ export default [
     name: 'Tripwire',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (10 + attacker.level/7),
-        ref: - (defender.ref * 0.2)
+        hp: -10 + (attacker.level * 0.142),
+        ref: -defender.ref * 0.2,
       },
       log: {
         type: 'damage (-REF)',
-        value: (10 + attacker.level/7),
+        value: 10 + (attacker.level * 0.142),
       },
     }),
   },
@@ -545,14 +547,14 @@ export default [
     name: 'Patience',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (20 + attacker.level/4),
+        hp: -20 + (attacker.level * 0.25),
       },
       attacker: {
-        flow: attacker.flow * 0.2
+        flow: attacker.flow * 0.2,
       },
       log: {
         type: 'damage (+FLOW)',
-        value: (20 + attacker.level/4),
+        value: 20 + (attacker.level * 0.25),
       },
     }),
   },
@@ -561,13 +563,13 @@ export default [
     name: 'Bear Trap',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (10 + attacker.level/4),
-        ref: - (defender.ref * 0.3),
-        acc: - (defender.acc * 0.3),
+        hp: -10 + (attacker.level * 0.25),
+        ref: -defender.ref * 0.3,
+        acc: -defender.acc * 0.3,
       },
       log: {
         type: 'damage (-REF -ACC)',
-        value: (10 + attacker.level/4),
+        value: 10 + (attacker.level * 0.25),
       },
     }),
   },
@@ -576,11 +578,11 @@ export default [
     name: 'Explosive Charge',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (40 + attacker.level/2),
+        hp: -40 + (attacker.level * 0.5),
       },
       log: {
         type: 'damage',
-        value: - (40 + attacker.level/2),
+        value: -40 + (attacker.level * 0.5),
       },
     }),
   },
@@ -590,12 +592,12 @@ export default [
     name: 'Tune Weapon',
     fire: (attacker, defender, rolls) => ({
       attacker: {
-        hp: (2 + attacker.level/5),
-        str: attacker.str * 0.2
+        hp: 2 + (attacker.level * 0.2),
+        str: attacker.str * 0.2,
       },
       log: {
         type: 'heal (+STR)',
-        value: (2 + attacker.level/5),
+        value: 2 + (attacker.level * 0.2),
       },
     }),
   },
@@ -604,11 +606,11 @@ export default [
     name: 'Potion',
     fire: (attacker, defender, rolls) => ({
       attacker: {
-        hp: (20 + attacker.level/4),
+        hp: 20 + (attacker.level * 0.25),
       },
       log: {
         type: 'heal',
-        value: (20 + attacker.level/4),
+        value: 20 + (attacker.level * 0.25),
       },
     }),
   },
@@ -617,11 +619,11 @@ export default [
     name: 'Runover',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - ( 35 + (attacker.level/5)),
+        hp: -35 + (attacker.level * 0.2),
       },
       log: {
         type: 'damage',
-        value: (35 + attacker.level/5),
+        value: 35 + (attacker.level * 0.2),
       },
     }),
   },
@@ -630,12 +632,12 @@ export default [
     name: 'Chemical Bomb',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - ( 10 + (attacker.level/4)),
-        con: - (defender.con * 0.3),
+        hp: -10 + (attacker.level * 0.25),
+        con: -defender.con * 0.3,
       },
       log: {
         type: 'damage (-CON)',
-        value: 10 + attacker.level/4,
+        value: 10 + (attacker.level * 0.25),
       },
     }),
   },
@@ -645,12 +647,12 @@ export default [
     name: 'Smart Hit',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (15 + attacker.level/4),
-        ref: - (defender.ref * 0.2)
+        hp: -15 + (attacker.level * 0.25),
+        ref: -defender.ref * 0.2,
       },
       log: {
         type: 'damage (-REF)',
-        value: (15 + attacker.level/4),
+        value: 15 + (attacker.level * 0.25),
       },
     }),
   },
@@ -659,12 +661,12 @@ export default [
     name: 'Calculated Blow',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (20 + attacker.level/4),
-        con: - (defender.con * 0.1)
+        hp: -20 + (attacker.level * 0.25),
+        con: -defender.con * 0.1,
       },
       log: {
         type: 'damage (-CON)',
-        value: (20 + attacker.level/4),
+        value: 20 + (attacker.level * 0.25),
       },
     }),
   },
@@ -673,15 +675,15 @@ export default [
     name: 'Sabotage',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (25 + attacker.level/4),
-        str: - (defender.str * 0.1),
-        ref: - (defender.ref * 0.1),
-        acc: - (defender.acc * 0.1),
-        con: - (defender.con * 0.1),
+        hp: -25 + (attacker.level * 0.25),
+        str: -defender.str * 0.1,
+        ref: -defender.ref * 0.1,
+        acc: -defender.acc * 0.1,
+        con: -defender.con * 0.1,
       },
       log: {
         type: 'damage (-STR -CON -REF -ACC)',
-        value: (25 + attacker.level/4),
+        value: 25 + (attacker.level * 0.25),
       },
     }),
   },
@@ -690,16 +692,16 @@ export default [
     name: 'Hammer Down',
     fire: (attacker, defender, rolls) => ({
       defender: {
-        hp: - (20 + attacker.level/5),
-        acc: - (defender.acc * 0.3),
-        ref: - (defender.ref * 0.3),
-        str: - (defender.str * 0.3),
-        con: - (defender.con * 0.3),
-        flow: - (defender.flow * 0.3),
+        hp: -20 + (attacker.level * 0.2),
+        acc: -defender.acc * 0.3,
+        ref: -defender.ref * 0.3,
+        str: -defender.str * 0.3,
+        con: -defender.con * 0.3,
+        flow: -defender.flow * 0.3,
       },
       log: {
         type: 'damage (-ALL STATS)',
-        value: (20 + attacker.level/5),
+        value: 20 + (attacker.level * 0.2),
       },
     }),
   },

--- a/src/game/models/stances.js
+++ b/src/game/models/stances.js
@@ -54,7 +54,7 @@ export default [
     description: 'You boost your defensive stats by concentrating on endurance.',
     skills: [
       {
-        id: 'meditate',
+        id: 'taunt',
         influence: 15,
       },
       {


### PR DESCRIPTION
Hi guys!

I wanted mostly to create the PR so others can see it for now. There's more info I want to add (like the baseline stats I used for each skill level, I'll edit this later.

Some of the the changes introduced with this PR:

* Balance all skills based on baseline stats taken from current skill values. (I may document these baseline values somewhere later)
* Overall nerf to debuff skills, since players are usually fighting higher levels and stat enemies than their own, these debuff percentages were having a huge impact on the results. What made this even worse was that debuff had higher percentages than buffs. This balance pass is considering "level one debuff" as 15% and a "level one buff" as 20%. Each "level" of those buff/debuff stats will be followed by a reduction in base and scaling damage or heal. So a 30% debuff will have similar damage than a 40% buff skill. Or a 15% debuff will be siimilar to a 20% debuff, etc)
* Mage's Arcane stance has higher overall damage stats than baseline. This is to counter the fact that they have almost no strategy attached to it (no buffs, just a minor debuff).
* Fighter's "Meditate" skill is renamed to "Taunt", because I didn't see much sense on doing damage while Meditating

Baseline damage/healing values I extracted from the previous values we had, I based on this one to balance out all the skills. If some tweaking needs to be done at this, skills need to be updated acordingly.

| DAMAGE SKILLS | 20% buff or 15% debuff | 40% buff or 30% debuff | 60% buff or 45% debuff | 80% buff or 60% debuff |
|---------------|------------------------|------------------------|------------------------|------------------------|
| Skill Tier 1  |     10 + lvl * 0.25    |     7  + lvl * 0.17    |     3  + lvl * 0.10    |                        |
| Skill Tier 2  |     20 + lvl * 0.35    |     15 + lvl * 0.25    |     10 + lvl * 0.15    |                        |
| Skill Tier 3  |     30 + lvl * 0.45    |     25 + lvl * 0.35    |     20 + lvl * 0.25    |                        |
| Skill Tier 4  |     40 + lvl * 0.55    |     33 + lvl * 0.43    |     25 + lvl * 0.3     |     17 + lvl * 0.17    |

| HEALING SKILLS | 20% buff or 15% debuff | 40% buff or 30% debuff | 60% buff or 45% debuff | 80% buff or 60% debuff |
|----------------|------------------------|------------------------|------------------------|------------------------|
| Skill Tier 1   |     10 + lvl * 0.2     |     6  + lvl * 0.15    |     3  + lvl * 0.1     |                        |
| Skill Tier 2   |     15 + lvl * 0.25    |     10 + lvl * 0.2     |     6 + lvl * 0.15     |                        |
| Skill Tier 3   |     20 + lvl * 0.3     |     15 + lvl * 0.25    |     10 + lvl * 0.2     |                        |
| Skill Tier 4   |     25 + lvl * 0.35    |     20 + lvl * 0.3     |     15 + lvl * 0.25    |     10 + lvl * 0.2     |

BTW, I basically created the baselines for Healing skills because we had very few skills for reference, I mostly based this table on Bulk Up (tier 4 + 3 buffs), Potion/Bandage (tier 2 no buffs) and Heal (tier 1 no buffs)

Besides this, I'd avoid to have more than two-three buffs/debuffs levels in a single skill and I think we only have cases of three debuff levels on Tier 4 Skills, which is good. I think the only exception to this right now is Mirage from the Mage's Debuff stance, which is a bit over the three levels (not exactly got to the 4th and the damage was adjusted too), but seems fitting.

Anyways, this is just a first pass attempt at balancing. We can use this as a base for future improvements based on data and player feedback.